### PR TITLE
使用blender内部剪切板代替pyperclip

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -114,7 +114,7 @@ class CP2U_PT_AddonPreferencesPanel(bpy.types.AddonPreferences):
         
 
 def register():
-    install.update_sys_path(site.getusersitepackages(), [])
+    # install.update_sys_path(site.getusersitepackages(), [])
     bpy.utils.register_class(CP2U_OT_CopyMatNodesOperator)
     bpy.utils.register_class(CP2U_PT_MatEditorPanel)
     bpy.utils.register_class(CP2U_OT_InstallPyperclip)

--- a/__init__.py
+++ b/__init__.py
@@ -41,20 +41,10 @@ class CP2U_OT_CopyMatNodesOperator(bpy.types.Operator):
 
     def execute(self, context):
         mats_str = ''
-        try:
-            import pyperclip
 
-            mats_str = generate_ue_mat_nodes.get_ue_mat_str(self.get_selected_nodes(context), context.window.height, self)
-            pyperclip.copy(mats_str)
-            self.report({'INFO'}, "Copy to clipboard.")
-        except ModuleNotFoundError:
-            print("Failed to import pyperclip module.")
-            self.report({'ERROR'}, "Failed to import pyperclip module.")
-            
-            # try refresh system path
-            import site
-            install.update_sys_path(site.getusersitepackages(), [])
-
+        mats_str = generate_ue_mat_nodes.get_ue_mat_str(self.get_selected_nodes(context), context.window.height, self)
+        context.window_manager.clipboard = mats_str
+        self.report({'INFO'}, "Copy to clipboard.")
         
         return {"FINISHED"}
 
@@ -115,12 +105,6 @@ class CP2U_PT_AddonPreferencesPanel(bpy.types.AddonPreferences):
 
     def draw(self, context):
         layout = self.layout
-
-        layout.label(text="Install PIP and pyperclip for Blender Python:")
-        row = layout.row()
-
-        row.operator("cp2u.install_pyperclip", text="Install Pyperclip", icon="IMPORT")
-
         # row = layout.row()
         # split = row.split(factor=0.3)
         # split.label(text="Copy Shortcut:")


### PR DESCRIPTION
context.window_manager.clipboard 允许读取和写入剪切板（str），使用此方法代替pyperclip
移除安装包相关的按钮和检测